### PR TITLE
Improvements

### DIFF
--- a/app/src/main/java/org/mabrarov/dockercomposeinitcontainer/Application.java
+++ b/app/src/main/java/org/mabrarov/dockercomposeinitcontainer/Application.java
@@ -10,8 +10,16 @@ import org.springframework.web.filter.CommonsRequestLoggingFilter;
 public class Application {
 
   public static void main(final String[] args) {
+    setJavaTrustStoreFile();
     setJavaTrustStorePassword();
     SpringApplication.run(Application.class, args);
+  }
+
+  private static void setJavaTrustStoreFile() {
+    val trustStoreFile = System.getenv("TRUST_STORE_FILE");
+    if (trustStoreFile != null) {
+      System.setProperty("javax.net.ssl.trustStore", trustStoreFile);
+    }
   }
 
   private static void setJavaTrustStorePassword() {

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,36 +1,48 @@
 version: '2.1'
 
+x-helper-dir: &helper-dir '/helper'
+x-helper-wrapper-script: &helper-wrapper-script '/helper/run.sh'
+x-helper-dockerize: &helper-dockerize '/helper/dockerize'
+
+x-config-dir: &config-dir '/config'
+x-keystore-file: &keystore-file '/config/keystore.p12'
+x-trust-store-file: &trust-store-file '/config/truststore.jks'
+
+x-https-keystore-password: &https-keystore-password 'pass'
+x-https-keystore-alias: &https-keystore-alias 'alias'
+x-trust-store-password: &trust-store-password 'password_of_6_chars_min'
+
 services:
   helper:
     image: 'abrarov/docker-compose-init-container-helper'
+    read_only: true
     volumes:
-      - '/helper'
+      - *helper-dir
   init:
     image: 'abrarov/docker-compose-init-container-initializer'
-    command:
-      - '/helper/run.sh'
+    command: *helper-wrapper-script
     environment:
       INIT_COMMAND: '/run.sh'
       CA_BUNDLE_FILE: '/ca-cert.crt'
-      TRUST_STORE_FILE: '/config/truststore.jks'
-      TRUST_STORE_PASSWORD: 'password_of_6_chars_min'
+      TRUST_STORE_FILE: *trust-store-file
+      TRUST_STORE_PASSWORD: *trust-store-password
       CA_CRT_FILE: '/ca-cert.crt'
       CRT_FILE: '/tls-cert.crt'
       KEY_FILE: '/tls-key.pem'
-      KEYSTORE_FILE: '/config/keystore.p12'
-      KEYSTORE_PASSWORD: 'pass'
-      KEY_ALIAS: 'alias'
-    volumes_from:
-      - 'helper:ro'
+      KEYSTORE_FILE: *keystore-file
+      KEYSTORE_PASSWORD: *https-keystore-password
+      KEY_ALIAS: *https-keystore-alias
     volumes:
-      - '/config'
+      - *config-dir
       - '../certificates/ca-cert.crt:/ca-cert.crt:ro'
       - '../certificates/tls-cert.crt:/tls-cert.crt:ro'
       - '../certificates/tls-key.pem:/tls-key.pem:ro'
+    volumes_from:
+      - 'helper:ro'
   app:
     image: 'abrarov/docker-compose-init-container-app'
     command:
-      - '/helper/dockerize'
+      - *helper-dockerize
       - '-wait'
       - 'tcp://init:8080'
       - '-timeout'
@@ -47,7 +59,7 @@ services:
     healthcheck:
       test:
         - 'CMD'
-        - '/helper/dockerize'
+        - *helper-dockerize
         - '-timeout'
         - '5s'
         - '-skip-tls-verify'
@@ -58,14 +70,15 @@ services:
       retries: 3
     environment:
       TINI_SUBREAPER: '1'
-      JAVA_TOOL_OPTIONS: '-XX:+PerfDisableSharedMem -Djavax.net.ssl.trustStore=/config/truststore.jks ${JAVA_OPTIONS:-}'
-      TRUST_STORE_PASSWORD: 'password_of_6_chars_min'
+      JAVA_TOOL_OPTIONS: '-XX:+PerfDisableSharedMem ${JAVA_OPTIONS:-}'
+      TRUST_STORE_FILE: *trust-store-file
+      TRUST_STORE_PASSWORD: *trust-store-password
       SERVER_PORT: '8443'
       SERVER_SSL_ENABLED: 'true'
-      SERVER_SSL_KEY_STORE: '/config/keystore.p12'
-      SERVER_SSL_KEY_STORE_PASSWORD: 'pass'
+      SERVER_SSL_KEY_STORE: *keystore-file
+      SERVER_SSL_KEY_STORE_PASSWORD: *https-keystore-password
       SERVER_SSL_KEY_STORE_TYPE: 'PKCS12'
-      SERVER_SSL_KEY_ALIAS: 'alias'
+      SERVER_SSL_KEY_ALIAS: *https-keystore-alias
     read_only: true
     volumes:
       - '/tmp'

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -50,8 +50,9 @@ services:
         - '/helper/dockerize'
         - '-timeout'
         - '5s'
+        - '-skip-tls-verify'
         - '-wait'
-        - 'tcp://localhost:8443'
+        - 'https://localhost:8443'
       interval: '30s'
       timeout: '5s'
       retries: 3

--- a/helper-image/pom.xml
+++ b/helper-image/pom.xml
@@ -41,10 +41,10 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://github.com/jwilder/dockerize/releases/download/v${dockerize.version}/dockerize-linux-amd64-v${dockerize.version}.tar.gz</url>
-                            <unpack>true</unpack>
+                            <url>https://github.com/powerman/dockerize/releases/download/v${dockerize.version}/dockerize-linux-x86_64</url>
                             <outputDirectory>${project.build.directory}</outputDirectory>
-                            <sha512>${dockerize.sha512}</sha512>
+                            <outputFileName>dockerize</outputFileName>
+                            <sha256>${dockerize.sha256}</sha256>
                         </configuration>
                     </execution>
                 </executions>

--- a/openshift/template.yml
+++ b/openshift/template.yml
@@ -55,7 +55,9 @@ objects:
               image: '${REGISTRY}/${NAMESPACE}/${APP}'
               env:
                 - name: 'JAVA_TOOL_OPTIONS'
-                  value: '-XX:+PerfDisableSharedMem -Djavax.net.ssl.trustStore=${CONFIG_DIR}/truststore.jks ${JAVA_OPTIONS}'
+                  value: '-XX:+PerfDisableSharedMem ${JAVA_OPTIONS}'
+                - name: 'TRUST_STORE_FILE'
+                  value: '${CONFIG_DIR}/truststore.jks'
                 - name: 'TRUST_STORE_PASSWORD'
                   valueFrom:
                     secretKeyRef:

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
         <busybox.sha512>89dafd4be9d51135ec8ad78a9ac24c29f47673a9fb3920dac9df81c7b6b850ad8e7219a0ded755c2b106a736804c9de3174302a2fba6130196919777cb516a4f</busybox.sha512>
         <httpecho.version>0.2.3</httpecho.version>
         <httpecho.sha512>a34fb083c95afb1e09725b2d6204c1a77548aaa3bd341cbaf65548586a496ed5284af6f2d0cfaec63b171992b143dd832e9395f634a3683c95315820e90cbf92</httpecho.sha512>
-        <dockerize.version>0.6.1</dockerize.version>
-        <dockerize.sha512>182e90d35bc9dd05fd567512fc0b35f612de80898324a29e2db182edf4eb0bca6e0b0cab6891f7e5b469383cdd70584543181737318439cecc6f310292b442af</dockerize.sha512>
+        <dockerize.version>0.12.0</dockerize.version>
+        <dockerize.sha256>5c241e7ec35a205cd53250585282462636ebb894072a4b34283dc3d9b7c9be29</dockerize.sha256>
         <jacoco.version>0.8.5</jacoco.version>
         <docker.verbose>true</docker.verbose>
         <docker.skip>true</docker.skip>


### PR DESCRIPTION
* Migrated to powerman/dockerize which is a forward development fork of original dockerize (jwilder/dockerize) and supports an option to skip HTTPS certificate validation when waiting on HTTPS resource.
* Optimization of Docker Compose project 